### PR TITLE
Fix rfid SPI symbol declaration

### DIFF
--- a/lib/MFRC522/MFRC522.h
+++ b/lib/MFRC522/MFRC522.h
@@ -20,6 +20,7 @@
 #ifndef MFRC522_SPI
 #define MFRC522_SPI SPI
 #endif
+extern SPIClass MFRC522_SPI;
 
 
 #ifndef MFRC522_SPICLOCK


### PR DESCRIPTION
## Summary
- declare `MFRC522_SPI` as extern in MFRC522.h
- keep `SPIClass rfidSPI(HSPI)` in main.cpp
- build heltec-v3 variant to ensure compile succeeds

## Testing
- `platformio run -e heltec-v3`

------
https://chatgpt.com/codex/tasks/task_e_684aaea82dd48320944727450350de84