### PR TITLE
Add RC522 pin macros for heltec_v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ ensure an SPI instance with that name is defined in your project. An
 `extern` declaration for this object now lives in `MFRC522.h`, so only the
 definition (e.g. `SPIClass rfidSPI(HSPI);`) is required.
 
+To override the MFRC522 pin assignments on the Heltec V3 variant, define
+`RC522_*_PIN` macros in your `platformio.ini`. For example:
+
+```
+[env:heltec-v3]
+build_flags =
+  -DRC522_SCK_PIN=5
+  -DRC522_MOSI_PIN=18
+  -DRC522_MISO_PIN=19
+  -DRC522_SS_PIN=21
+  -DRC522_RST_PIN=22
+```
+
 ## Stats
 
 ![Alt](https://repobeats.axiom.co/api/embed/8025e56c482ec63541593cc5bd322c19d5c0bdcf.svg "Repobeats analytics image")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,11 +40,6 @@
 #include <utility>
 #ifdef HELTEC_V3
 #include <MFRC522.h>
-#define RC522_SCK 25
-#define RC522_MOSI 32
-#define RC522_MISO 33
-#define RC522_SS 26
-#define RC522_RST 27
 #endif
 
 #ifdef ARCH_ESP32
@@ -151,7 +146,7 @@ SPIClass SPI1(HSPI);
 #endif
 #ifdef HELTEC_V3
 SPIClass rfidSPI(HSPI);
-static MFRC522 rfid(RC522_SS, RC522_RST);
+static MFRC522 rfid(RC522_SS_PIN, RC522_RST_PIN);
 static String lastRfidUid = "";
 static uint32_t lastRfidTime = 0;
 static float lastAckSnr = 0;
@@ -899,7 +894,7 @@ void setup()
     SPI.setFrequency(4000000);
 #endif
 #ifdef HELTEC_V3
-    rfidSPI.begin(RC522_SCK, RC522_MISO, RC522_MOSI, RC522_SS);
+    rfidSPI.begin(RC522_SCK_PIN, RC522_MISO_PIN, RC522_MOSI_PIN, RC522_SS_PIN);
     rfid.PCD_Init();
 #endif
 #endif

--- a/variants/heltec_v3/variant.h
+++ b/variants/heltec_v3/variant.h
@@ -40,3 +40,20 @@
 
 #define SX126X_DIO2_AS_RF_SWITCH
 #define SX126X_DIO3_TCXO_VOLTAGE 1.8
+
+// MFRC522 RFID reader pins
+#ifndef RC522_SCK_PIN
+#define RC522_SCK_PIN 25
+#endif
+#ifndef RC522_MOSI_PIN
+#define RC522_MOSI_PIN 32
+#endif
+#ifndef RC522_MISO_PIN
+#define RC522_MISO_PIN 33
+#endif
+#ifndef RC522_SS_PIN
+#define RC522_SS_PIN 26
+#endif
+#ifndef RC522_RST_PIN
+#define RC522_RST_PIN 27
+#endif


### PR DESCRIPTION
## Summary
- define RC522 pin macros in `variants/heltec_v3/variant.h`
- use new macros in `src/main.cpp`
- document how to override RC522 pins in `platformio.ini`

## Testing
- `platformio run -e heltec-v3`

------
https://chatgpt.com/codex/tasks/task_e_684abdefd68083209ee17aa64cda61ad