### PR TITLE
Center boot bitmaps

### DIFF
--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -162,13 +162,11 @@ static void drawIconScreen(const char *upperMsg, OLEDDisplay *display, OLEDDispl
     // needs to be drawn relative to x and y
 
     // draw centered icon left to right and centered above the one line of app text
-    display->drawXbm(x + (SCREEN_WIDTH - icon_width) / 2, y + (SCREEN_HEIGHT - FONT_HEIGHT_MEDIUM - icon_height) / 2 + 2,
-                     icon_width, icon_height, icon_bits);
+    // Center icon vertically without reserving space for a title
+    display->drawXbm(x + (SCREEN_WIDTH - icon_width) / 2,
+                     y + (SCREEN_HEIGHT - icon_height) / 2, icon_width, icon_height, icon_bits);
 
-    display->setFont(FONT_MEDIUM);
     display->setTextAlignment(TEXT_ALIGN_LEFT);
-    const char *title = "meshtastic.org";
-    display->drawString(x + getStringCenteredX(title), y + SCREEN_HEIGHT - FONT_HEIGHT_MEDIUM, title);
     display->setFont(FONT_SMALL);
 
     // Draw region in upper left
@@ -189,13 +187,11 @@ static void drawIconScreen(const char *upperMsg, OLEDDisplay *display, OLEDDispl
 static void drawBitmapScreen(const char *upperMsg, OLEDDisplay *display, OLEDDisplayUiState *state, int16_t x, int16_t y,
                              uint16_t width, uint16_t height, const uint8_t *bits)
 {
+    // Center bitmap vertically without reserving space for a title
     display->drawXbm(x + (SCREEN_WIDTH - width) / 2,
-                     y + (SCREEN_HEIGHT - FONT_HEIGHT_MEDIUM - height) / 2 + 2, width, height, bits);
+                     y + (SCREEN_HEIGHT - height) / 2, width, height, bits);
 
-    display->setFont(FONT_MEDIUM);
     display->setTextAlignment(TEXT_ALIGN_LEFT);
-    const char *title = "meshtastic.org";
-    display->drawString(x + getStringCenteredX(title), y + SCREEN_HEIGHT - FONT_HEIGHT_MEDIUM, title);
     display->setFont(FONT_SMALL);
 
     if (upperMsg)


### PR DESCRIPTION
## Summary
- boot icon screens no longer display `meshtastic.org`
- center boot images vertically since the bottom text is removed

## Testing
- `platformio test -e coverage -v --junit-output-path testreport.xml` *(fails: libusb-1.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_684be0320f5c832091357f170ee2e17c