### PR TITLE
Extend ACK alert display

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -167,6 +167,7 @@ struct AckHandler {
                     ledForceOn.set(false);
                     delay(50);
                 }
+                delay(5000);
                 screen->endAlert();
             }
         }


### PR DESCRIPTION
## Summary
- keep ACK alerts on screen for 5 seconds

## Testing
- `platformio test -e coverage -v` *(fails: aborted)*

------
https://chatgpt.com/codex/tasks/task_e_684be2e63be88320897c6efbb06e9423