### PR TITLE
Fix alert message memory issue

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -159,8 +159,20 @@ struct AckHandler {
                 msg += (char)mp->decoded.payload.bytes[i];
             String prefix = String(owner.short_name) + ":";
             if (msg.startsWith(prefix)) {
-                if (screen)
-                    screen->startAlert(msg.c_str());
+                if (screen) {
+                    // Capture a copy of the message so that the alert frame can
+                    // safely use it once the handler returns.
+                    String msgCopy = msg;
+                    screen->startAlert([msgCopy](OLEDDisplay *display,
+                                                OLEDDisplayUiState *state,
+                                                int16_t x, int16_t y) -> void {
+                        uint16_t x_offset = display->width() / 2;
+                        display->setTextAlignment(TEXT_ALIGN_CENTER);
+                        display->setFont(FONT_MEDIUM);
+                        display->drawString(x_offset + x, 26 + y,
+                                           msgCopy.c_str());
+                    });
+                }
                 for (int i = 0; i < 5; i++) {
                     ledForceOn.set(true);
                     delay(50);


### PR DESCRIPTION
## Summary
- ensure ack alert strings persist after AckHandler exits

