### PR TITLE
Remove colons from RFID UID

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1464,7 +1464,6 @@ void loop()
         if (rfid.PICC_IsNewCardPresent() && rfid.PICC_ReadCardSerial()) {
             String uid = "";
             for (byte i = 0; i < rfid.uid.size; i++) {
-                if (i) uid += ":";
                 uid += String(rfid.uid.uidByte[i], HEX);
             }
             uid.toUpperCase();


### PR DESCRIPTION
## Summary
- send scanned RFID UIDs without separators

