### PR TITLE
Center ACK alert text

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -180,13 +180,14 @@ struct AckHandler {
                     screen->startAlert([msgCopy](OLEDDisplay *display,
                                                 OLEDDisplayUiState *state,
                                                 int16_t x, int16_t y) -> void {
-                        display->setTextAlignment(TEXT_ALIGN_LEFT);
+                        display->setTextAlignment(TEXT_ALIGN_CENTER);
                         if (display->height() <= 64)
                             display->setFont(FONT_SMALL);
                         else
                             display->setFont(FONT_MEDIUM);
-                        display->drawStringMaxWidth(0 + x, 26 + y,
-                                                    x + display->getWidth(),
+                        int16_t xOffset = display->getWidth() / 2;
+                        display->drawStringMaxWidth(x + xOffset, 26 + y,
+                                                    display->getWidth(),
                                                     msgCopy.c_str());
                     });
                 }


### PR DESCRIPTION
## Summary
- center ack text when an acknowledgement is received
- keep small font on short displays but default to medium