### PR TITLE
Fix logo timeout linkage and ack alert refresh

### DIFF
--- a/src/graphics/Screen.h
+++ b/src/graphics/Screen.h
@@ -131,6 +131,8 @@ class Point
 namespace graphics
 {
 
+extern uint32_t logo_timeout;
+
 // Forward declarations
 class Screen;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -136,7 +136,9 @@ UdpMulticastHandler *udpHandler = nullptr;
 float tcxoVoltage = SX126X_DIO3_TCXO_VOLTAGE; // if TCXO is optional, put this here so it can be changed further down.
 #endif
 
+namespace graphics {
 extern uint32_t logo_timeout;
+}
 
 #ifdef MESHTASTIC_INCLUDE_NICHE_GRAPHICS
 void setupNicheGraphics();
@@ -1461,7 +1463,7 @@ void loop()
 #ifdef HELTEC_V3
     if (waitingForAck) {
         uint32_t now = millis();
-        if (screen && ackAlert && now - ackAlertLastShown >= logo_timeout) {
+        if (screen && ackAlert && now - ackAlertLastShown >= graphics::logo_timeout) {
             screen->startAlert(ackAlert);
             ackAlertDisplayed = true;
             ackAlertLastShown = now;


### PR DESCRIPTION
## Summary
- fix undefined `logo_timeout` by using the graphics namespace
- refresh the waiting alert using `graphics::logo_timeout`

## Testing
- `pio test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee15c41c08320a9bdae088c3a40f5